### PR TITLE
Make mode aware of AI Bots, add mechanism to remove them and leave space for human players

### DIFF
--- a/ANA_PB.opy
+++ b/ANA_PB.opy
@@ -12,7 +12,7 @@ settings "settings.opy.json"
 
 # Toggle debug mode
 #!define DEBUG_MODE false
-# # # # # # # # # # # # # # # # # # # # # # 
+# # # # # # # # # # # # # # # # # # # # # #
 
 # Pre-match
 #!include "variables.opy"
@@ -23,6 +23,7 @@ settings "settings.opy.json"
 #!include "playzones.opy"
 #!include "mapObjects.opy"
 #!include "bots.opy"
+#!include "ai_bots.opy"
 
 #!include "systemMessages.opy"
 

--- a/ai_bots.opy
+++ b/ai_bots.opy
@@ -1,0 +1,22 @@
+#!mainFile "ANA_PB.opy"
+
+rule "Remove AI bots to leave space for human players":
+    @Event playerJoined
+    @Condition getNumberOfPlayers(Team.ALL) - getNumberOfDummyBots(Team.ALL) == getNumberOfSlots(Team.ALL)
+
+    wait() # let the setup playerJoined rule run first, so IsAIBot is set
+
+    TempAIBotBeingRemoved = nextAIBot
+
+    if not TempAIBotBeingRemoved:
+        return
+
+    waitUntil(hostPlayer.hasSpawned(), 99999)
+    smallMessage(hostPlayer, "    {} Removing {} to leave space for more human players".format(iconString(Icon.BOLT), TempAIBotBeingRemoved))
+
+    removeFromGame(TempAIBotBeingRemoved)
+    waitUntil(not entityExists(TempAIBotBeingRemoved), 2)
+
+    # There may be AI Bots in the lobby waiting to join in. Let's remove those too.
+    if RULE_CONDITION:
+        goto RULE_START

--- a/macros.opy
+++ b/macros.opy
@@ -23,7 +23,10 @@
 #!define distanceFromPointToPlayer(s, p) (distance(s, p) if p != null else 999999)
 #!define distanceFromPointToPlayerBetween(s, p, lower, upper) (abs(distance(s, p) - (upper + lower) / 2) <= (upper - lower) / 2 if p != null else true)
 
+#!define getNumberOfDummyBots(team) len([player for player in getPlayers(team) if player.isDummy()])
 #!define getNumberOfAIBots(team) len([player for player in getPlayers(team) if player.IsAIBot])
+
+#!define nextAIBot [player for player in getAllPlayers() if player.IsAIBot][0]
 #!define nextAIBotName "​ [ -C°▥°]-C Ana Bot #{}".format(getNumberOfAIBots(Team.ALL))
 
 #!define customGreen (rgb(63, 191, 116))

--- a/macros.opy
+++ b/macros.opy
@@ -23,6 +23,9 @@
 #!define distanceFromPointToPlayer(s, p) (distance(s, p) if p != null else 999999)
 #!define distanceFromPointToPlayerBetween(s, p, lower, upper) (abs(distance(s, p) - (upper + lower) / 2) <= (upper - lower) / 2 if p != null else true)
 
+#!define getNumberOfAIBots(team) len([player for player in getPlayers(team) if player.IsAIBot])
+#!define nextAIBotName "​ [ -C°▥°]-C Ana Bot #{}".format(getNumberOfAIBots(Team.ALL))
+
 #!define customGreen (rgb(63, 191, 116))
 #!define rSaturation 0.55
 #!define rValue 1.0

--- a/setup.opy
+++ b/setup.opy
@@ -31,15 +31,23 @@ rule "Start match sooner & pause timer":
 rule "Detect players": # Differentiate players from spectators & bots
     @Event playerJoined
     @Condition not eventPlayer.isDummy()
-    
-    eventPlayer.IsPlayer = true
+
+    eventPlayer.startForcingName(nextAIBotName)
+    if "{}".format(eventPlayer) == nextAIBotName:
+        eventPlayer.IsPlayer = false
+        eventPlayer.IsAIBot = true
+    else:
+        eventPlayer.IsPlayer = true
+        eventPlayer.IsAIBot = false
+        eventPlayer.stopForcingName()
+
     eventPlayer.setRespawnTime(CUSTOM_RESPAWN_TIME)
 
 
 rule "Restart game when lobby is empty": # For when I spectate randoms
     @Event playerLeft
     @Condition not MatchEnded
-    
+
     if len(getPlayersOnHero(Hero.ANA, Team.ALL)) == 0:
         restartMatch()
 

--- a/variables.opy
+++ b/variables.opy
@@ -236,3 +236,4 @@ playervar OofText
 playervar Temp
 
 globalvar SlowMo = 100
+globalvar TempAIBotBeingRemoved

--- a/variables.opy
+++ b/variables.opy
@@ -217,7 +217,8 @@ playervar FixMovementBug # delete this system when blizz fixes the bug
 
 
 # TRACKERS
-playervar IsPlayer 
+playervar IsPlayer
+playervar IsAIBot
 playervar LastSleptBy
 playervar SleepUsedAndDied = true    # detect when a sleeping player should be awoken due to their LastSleptBy dying
 playervar SleepLock     # needs reworked


### PR DESCRIPTION
> **Note**
> If you need help figuring out what to do with this "Pull Request", ask us on Discord ;)

Since people prefer to join lobbies with at least some people in them, I usually add some AI Bots to inflate the player count in the game browser.
However, Ana AI Bots have the benefit of actually spawning, moving around, and shooting, so I usually end up leaving them in when people start joining. A problem emerges when the lobby gets full, and real people can't join because some AI Bot is taking a slot, and I'm too busy shooting Anas to do something about it.

So my solution is as follows:
1. When the lobby gets full, find an AI Bot and remove them from the game
    - Inform the host about this so they know to add them back
2. While we are at it, highlight AI Bots with a custom name

![](https://github.com/JinkoMinko/ana-paintball/assets/6181929/e3885b69-4c9a-4b37-977d-2906985f9d5f)
