### PR TITLE
Some fixes to the AI bot removal rule

### DIFF
--- a/ai_bots.opy
+++ b/ai_bots.opy
@@ -1,10 +1,11 @@
 #!mainFile "ANA_PB.opy"
 
 rule "Remove AI bots to leave space for human players":
-    @Event playerJoined
+    @Event eachPlayer
     @Condition getNumberOfPlayers(Team.ALL) - getNumberOfDummyBots(Team.ALL) == getNumberOfSlots(Team.ALL)
+    @Condition eventPlayer == nextAIBot
 
-    wait() # let the setup playerJoined rule run first, so IsAIBot is set
+    wait(0, Wait.ABORT_WHEN_FALSE) # let the setup playerJoined rule run first, so IsAIBot is set
 
     TempAIBotBeingRemoved = nextAIBot
 
@@ -12,7 +13,7 @@ rule "Remove AI bots to leave space for human players":
         return
 
     waitUntil(hostPlayer.hasSpawned(), 99999)
-    smallMessage(hostPlayer, "    {} Removing {} to leave space for more human players".format(iconString(Icon.BOLT), TempAIBotBeingRemoved))
+    smallMessage(hostPlayer, "    {0} Removing {1} to leave space for more human players".format(iconString(Icon.BOLT), TempAIBotBeingRemoved))
 
     removeFromGame(TempAIBotBeingRemoved)
     waitUntil(not entityExists(TempAIBotBeingRemoved), 2)

--- a/ai_bots.opy
+++ b/ai_bots.opy
@@ -8,12 +8,13 @@ rule "Remove AI bots to leave space for human players":
     wait(0, Wait.ABORT_WHEN_FALSE) # let the setup playerJoined rule run first, so IsAIBot is set
 
     TempAIBotBeingRemoved = nextAIBot
+    TempAIBotBeingRemovedName = "{0}".format(TempAIBotBeingRemoved)
 
     if not TempAIBotBeingRemoved:
         return
 
     waitUntil(hostPlayer.hasSpawned(), 99999)
-    smallMessage(hostPlayer, "    {0} Removing {1} to leave space for more human players".format(iconString(Icon.BOLT), TempAIBotBeingRemoved))
+    smallMessage(hostPlayer, "    {0} Removing {1} to leave space for more human players".format(iconString(Icon.BOLT), TempAIBotBeingRemovedName))
 
     removeFromGame(TempAIBotBeingRemoved)
     waitUntil(not entityExists(TempAIBotBeingRemoved), 2)

--- a/variables.opy
+++ b/variables.opy
@@ -237,3 +237,4 @@ playervar Temp
 
 globalvar SlowMo = 100
 globalvar TempAIBotBeingRemoved
+globalvar TempAIBotBeingRemovedName


### PR DESCRIPTION
- Avoid infinite loop if the Host adds a lot of AI bots at the same time, filling up the lobby slots
- Store AI bot's name before removing them, to ensure it is available by the time the `smallMessage`'s string is evaluated