### PR TITLE
Remove scores from human players that killed AI bots once the bot leaves the game

### DIFF
--- a/ai_bots.opy
+++ b/ai_bots.opy
@@ -15,6 +15,7 @@ rule "Store slot of AI bot that just joined":
 
 rule "Remove scores from players who killed the AI bot that just left":
     @Event playerLeft
+    @Condition RevertKillsToAIBotsEnabled
 
     TempLeavingAIBotSlot = -1
     for i in range(getNumberOfSlots(Team.ALL)):

--- a/ai_bots.opy
+++ b/ai_bots.opy
@@ -1,5 +1,37 @@
 #!mainFile "ANA_PB.opy"
 
+rule "Count human kills of AI bots":
+    @Event playerDied
+    @Condition not attacker.IsAIBot
+    @Condition victim.IsAIBot
+
+    attacker.AIBotKillsPerSlot[victim.getSlot()] += 1
+
+rule "Store slot of AI bot that just joined":
+    @Event eachPlayer
+    @Condition eventPlayer.IsAIBot
+
+    AIBotSlots.append(eventPlayer.getSlot())
+
+rule "Remove scores from players who killed the AI bot that just left":
+    @Event playerLeft
+
+    TempLeavingAIBotSlot = -1
+    for i in range(getNumberOfSlots(Team.ALL)):
+        if i in AIBotSlots and (not entityExists(getPlayersInSlot(i, Team.ALL)) or not getPlayersInSlot(i, Team.ALL).IsAIBot):
+            TempLeavingAIBotSlot = i
+            break
+
+    if TempLeavingAIBotSlot >= 0:
+        AIBotSlots.remove(TempLeavingAIBotSlot)
+
+        for i in range(getNumberOfSlots(Team.ALL)):
+            if not getPlayersInSlot(i, Team.ALL).IsAIBot and not getPlayersInSlot(i, Team.ALL).isDummy():
+                getPlayersInSlot(i, Team.ALL).setScore(
+                    getPlayersInSlot(i, Team.ALL).getScore() - getPlayersInSlot(i, Team.ALL).AIBotKillsPerSlot[TempLeavingAIBotSlot]
+                )
+                getPlayersInSlot(i, Team.ALL).AIBotKillsPerSlot[TempLeavingAIBotSlot] = 0
+
 rule "Remove AI bots to leave space for human players":
     @Event eachPlayer
     @Condition getNumberOfPlayers(Team.ALL) - getNumberOfDummyBots(Team.ALL) == getNumberOfSlots(Team.ALL)

--- a/variables.opy
+++ b/variables.opy
@@ -179,6 +179,14 @@ globalvar NanoNukeBot
 globalvar PetraPunches    # Petra's Floorbreaker bot hits count
 
 
+# AI BOTS
+globalvar TempAIBotBeingRemoved
+globalvar TempAIBotBeingRemovedName
+globalvar TempLeavingAIBotSlot
+globalvar AIBotSlots = []
+playervar AIBotKillsPerSlot
+
+
 # HONOR SYSTEM
 playervar HonorQueue = []
 playervar HonorBar = 0
@@ -236,5 +244,3 @@ playervar OofText
 playervar Temp
 
 globalvar SlowMo = 100
-globalvar TempAIBotBeingRemoved
-globalvar TempAIBotBeingRemovedName

--- a/variables.opy
+++ b/variables.opy
@@ -182,6 +182,14 @@ globalvar PetraPunches    # Petra's Floorbreaker bot hits count
 # AI BOTS
 globalvar TempAIBotBeingRemoved
 globalvar TempAIBotBeingRemovedName
+
+globalvar RevertKillsToAIBotsEnabled = createWorkshopSetting(
+    bool,
+    "AI Bots",
+    "Revert kills against removed AI bots",
+    true,
+    0
+)
 globalvar TempLeavingAIBotSlot
 globalvar AIBotSlots = []
 playervar AIBotKillsPerSlot


### PR DESCRIPTION
- Keep track of how many kills a human player has done towards an AI bot (`AIBotKillsPerSlot[aiBot.getSlot()]`)
- When an AI bot leaves the game, remove score equal to the amount of kills the human player got on that bot
- Allow hosts to disable this behaviour through a workshop setting

Because `eventPlayer` is not available during `playerLeft`, I also have to keep track of the slots occupied by AI bots (`AIBotSlots`), and use that to gather which slot doesn't contain an AI bot after the AI bot has left (`TempLeavingAIBotSlot`).